### PR TITLE
Corresponds rye owner transfer to astral

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -9,7 +9,7 @@ inputs:
   version:
     required: true
     description: rye version
-    # renovate: depName=mitsuhiko/rye datasource=github-releases
+    # renovate: depName=astral-sh/rye datasource=github-releases
     default: '0.30.0'
   use-uv:
     required: false


### PR DESCRIPTION
Currently, rye maintained under https://github.com/astral-sh/rye