### PR TITLE
Change Rye setup script URL

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,7 @@ runs:
       RYE_INSTALL_OPTION: '--yes'
       RYE_VERSION: ${{ inputs.version }}
     run: |
-      curl -sSf https://rye-up.com/get | bash
+      curl -sSf https://rye.astral.sh/get | bash
 
   - name: setup rye path
     shell: bash


### PR DESCRIPTION
https://rye-up.com/get is continuously inaccessible. (https://github.com/astral-sh/rye/issues/1111)

So, setup rye using this action fails.

According to https://github.com/astral-sh/rye/issues/1111#issuecomment-2126154422, rye-up.com is moved to rye.astral.sh. Also, when rye-up.com is restored, rye-up.com will redirect to rye.astral.sh.

I changed the URL from rye-up.com to rye.astral.sh to retrieve rye.


